### PR TITLE
Bug Fixed

### DIFF
--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -73,7 +73,7 @@ export default function Experience({ isMobile }: { isMobile: boolean }) {
                       : "0.4rem solid rgba(255, 255, 255, 0.5)",
                 }}
                 date={item.date}
-                icon={item.icon}
+                icon={<>{item.icon}</>}
                 iconStyle={{
                   background:
                     theme === "light" ? "white" : "rgba(255, 255, 255, 0.15)",


### PR DESCRIPTION
Type 'FunctionComponentElement<IconBaseProps>' is not assignable to type 'ReactNode'.

<img width="1034" alt="SCR-20240527-krpm" src="https://github.com/Codefreyy/joy-personal-portfolio/assets/139340982/db9e486a-273d-48c3-8449-e473a70376cf">

Environment:
Yarn 1.22.22
Npm 10.2.4